### PR TITLE
drop unique constraint on url field to properly record sessions

### DIFF
--- a/migrations/20260214_drop_unique_on_swissrpg_event_url.down.sql
+++ b/migrations/20260214_drop_unique_on_swissrpg_event_url.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE swissrpg_event
+ADD CONSTRAINT swissrpg_event_url_key UNIQUE (url);
+
+COMMIT;

--- a/migrations/20260214_drop_unique_on_swissrpg_event_url.up.sql
+++ b/migrations/20260214_drop_unique_on_swissrpg_event_url.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE swissrpg_event
+DROP CONSTRAINT IF EXISTS swissrpg_event_url_key;
+
+COMMIT;


### PR DESCRIPTION
We currently have a missmatch between https://github.com/dthul/discord-bot/blob/master/schema.sql and https://github.com/dthul/discord-bot/blob/master/migrations/20250810_swissrpg_events.up.sql where we have a unique constraint on the `swissrpg_event.url` column.

This is an issue, since events on https://signup.swissrpg.ch an event series always keeps the same url, regardless of sessions. Therefore we can only ever insert 1 session per event series, which leads to the issue where hyperion spams channels with requests to schedule a new session.

Example based on https://signup.swissrpg.ch/event/0199da61-84e3-77eb-a098-f4269f8d5791
```
select * from event_series where swissrpg_event_series_id = '0199da61-84e3-77eb-a098-f4269f8d5791';
select * from event_series_text_channel where discord_id=1220798348781555712;
select * from event where event_series_id=2547;
```
--> This shows the newest entry as `id = 9188`, for the session that happened 2025-10-25 (which also is the first session on signup.swissrpg.ch). All sessions before that are legacy Meetup sessions.

Checking the `swissrpg_event` table with the uuids of all sessions since 9188:
```
select * from swissrpg_event from swissrpg_id where swissrpg_id IN ('019c590c-d50e-7fdd-a395-f07243dc4d74', '019c1acd-0ff8-7ddf-b6f7-9e237df6754e', '019afda8-0aeb-7254-85b9-a4e8f62df555', '019afda7-5747-7901-bc8d-89e52281f4f1', '019aa7df-4f53-7b7a-8d71-b3c9200601f8', '019a442e-c11c-7b18-9e63-3c60aee7f86a', '0199da61-850d-79c5-bdd4-8075173c25dd');
```
--> This only shows 1 entry, the one with `event_id = 9188`.

From what I can tell, in https://github.com/dthul/discord-bot/blob/master/lib/src/swissrpg/sync.rs#L208 we try to insert a row for the session uuid, with the event series public url. Since the public url of the event series stays the same between sessions, this can't work.