### PR TITLE
feature: Add Voice Channel for Online Sessions

### DIFF
--- a/lib/src/common_event.rs
+++ b/lib/src/common_event.rs
@@ -143,11 +143,7 @@ impl
             });
 
         // Check if event is online based on location tag
-        let is_online = event_series
-            .tags
-            .iter()
-            .any(|tag| tag.tag_type == "location" && tag.code == "online")
-            || venue.is_none();
+        let is_online = crate::swissrpg::sync::event_series_is_online(&event_series.tags);
 
         CommonEventDetails {
             id: session.uuid.to_string(),
@@ -160,5 +156,44 @@ impl
             rsvps_closed: !session.rsvp_open,
             short_url: event_series.public_url.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swissrpg::schema::{Event, Session, Tag, User};
+    use uuid::Uuid;
+
+    #[test]
+    fn swissrpg_event_without_venue_is_not_online_without_online_tag() {
+        let event = Event {
+            uuid: Uuid::new_v4(),
+            title: "Test".to_string(),
+            public_url: "https://example.com".to_string(),
+            organisers: vec![],
+            description: None,
+            current_session: None,
+            upcoming_sessions: vec![],
+            legacy_id: None,
+            tags: vec![Tag {
+                code: "mystery".to_string(),
+                value: "Mystery".to_string(),
+                tag_type: "location".to_string(),
+            }],
+        };
+        let session = Session {
+            uuid: Uuid::new_v4(),
+            number: 1,
+            start: Utc::now(),
+            attendees: Vec::<User>::new(),
+            rsvp_open: true,
+            open_seats: 1,
+        };
+
+        let common_event = CommonEventDetails::from((&event, &session));
+
+        assert!(!common_event.is_online);
+        assert!(common_event.venue.is_some());
     }
 }

--- a/lib/src/common_event.rs
+++ b/lib/src/common_event.rs
@@ -72,7 +72,7 @@ impl
         let venue = event_series
             .tags
             .iter()
-            .find(|tag| tag.tag_type == "location")
+            .find(|tag| tag.tag_type == crate::swissrpg::schema::TAG_TYPE_LOCATION)
             .and_then(|location_tag| {
                 // Try to match location names to coordinates
                 // This is a simplified implementation - in production you might want
@@ -129,7 +129,7 @@ impl
                         city: Some("St. Gallen".to_string()),
                     }),
                     location_code => {
-                        if location_code == "online" {
+                        if location_code == crate::swissrpg::schema::LOCATION_CODE_ONLINE {
                             None
                         } else {
                             Some(CommonVenue {
@@ -143,7 +143,7 @@ impl
             });
 
         // Check if event is online based on location tag
-        let is_online = crate::swissrpg::sync::event_series_is_online(&event_series.tags);
+        let is_online = crate::swissrpg::schema::event_series_is_online(&event_series.tags);
 
         CommonEventDetails {
             id: session.uuid.to_string(),
@@ -166,7 +166,7 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn swissrpg_event_without_venue_is_not_online_without_online_tag() {
+    fn swissrpg_event_with_non_online_location_tag_is_not_online_and_has_venue() {
         let event = Event {
             uuid: Uuid::new_v4(),
             title: "Test".to_string(),
@@ -179,7 +179,7 @@ mod tests {
             tags: vec![Tag {
                 code: "mystery".to_string(),
                 value: "Mystery".to_string(),
-                tag_type: "location".to_string(),
+                tag_type: crate::swissrpg::schema::TAG_TYPE_LOCATION.to_string(),
             }],
         };
         let session = Session {
@@ -195,5 +195,37 @@ mod tests {
 
         assert!(!common_event.is_online);
         assert!(common_event.venue.is_some());
+    }
+
+    #[test]
+    fn swissrpg_event_with_online_tag_is_online_without_venue() {
+        let event = Event {
+            uuid: Uuid::new_v4(),
+            title: "Test".to_string(),
+            public_url: "https://example.com".to_string(),
+            organisers: vec![],
+            description: None,
+            current_session: None,
+            upcoming_sessions: vec![],
+            legacy_id: None,
+            tags: vec![Tag {
+                code: crate::swissrpg::schema::LOCATION_CODE_ONLINE.to_string(),
+                value: "Online".to_string(),
+                tag_type: crate::swissrpg::schema::TAG_TYPE_LOCATION.to_string(),
+            }],
+        };
+        let session = Session {
+            uuid: Uuid::new_v4(),
+            number: 1,
+            start: Utc::now(),
+            attendees: Vec::<User>::new(),
+            rsvp_open: true,
+            open_seats: 1,
+        };
+
+        let common_event = CommonEventDetails::from((&event, &session));
+
+        assert!(common_event.is_online);
+        assert!(common_event.venue.is_none());
     }
 }

--- a/lib/src/free_spots.rs
+++ b/lib/src/free_spots.rs
@@ -322,14 +322,12 @@ impl EventCollector {
     fn event_location(event: &CommonEventDetails) -> Option<Location> {
         let venue = match &event.venue {
             Some(venue) => venue,
-            None => {
-                // Event doesn't have a venue? Assume that it's online
-                return Some(Location::Online);
-            }
+            None => return None,
         };
         // Is this event online?
         if event.is_online
-            || crate::meetup::sync::ONLINE_REGEX.is_match(event.description.as_deref().unwrap_or(""))
+            || crate::meetup::sync::ONLINE_REGEX
+                .is_match(event.description.as_deref().unwrap_or(""))
         {
             return Some(Location::Online);
         }
@@ -344,5 +342,28 @@ impl EventCollector {
         let point = Point::new(venue.lng, venue.lat);
         let location = Location::closest(point);
         Some(location)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn event_without_venue_is_not_classified_as_online_by_default() {
+        let event = CommonEventDetails {
+            id: "1".to_string(),
+            title: "Test".to_string(),
+            description: None,
+            date_time: Utc::now(),
+            venue: None,
+            is_online: false,
+            num_free_spots: 1,
+            rsvps_closed: false,
+            short_url: "https://example.com".to_string(),
+        };
+
+        assert_eq!(EventCollector::event_location(&event), None);
     }
 }

--- a/lib/src/free_spots.rs
+++ b/lib/src/free_spots.rs
@@ -320,10 +320,6 @@ impl EventCollector {
 
     // Figure out which location (if any) an event belongs to
     fn event_location(event: &CommonEventDetails) -> Option<Location> {
-        let venue = match &event.venue {
-            Some(venue) => venue,
-            None => return None,
-        };
         // Is this event online?
         if event.is_online
             || crate::meetup::sync::ONLINE_REGEX
@@ -331,6 +327,10 @@ impl EventCollector {
         {
             return Some(Location::Online);
         }
+        let venue = match &event.venue {
+            Some(venue) => venue,
+            None => return None,
+        };
         // Doesn't seem to be an online event.
         // Check if we know the city by name
         if let Some(city) = &venue.city {
@@ -349,21 +349,64 @@ impl EventCollector {
 mod tests {
     use super::*;
     use chrono::Utc;
+    use uuid::Uuid;
 
-    #[test]
-    fn event_without_venue_is_not_classified_as_online_by_default() {
-        let event = CommonEventDetails {
+    fn test_event(venue: Option<crate::common_event::CommonVenue>, is_online: bool) -> CommonEventDetails {
+        CommonEventDetails {
             id: "1".to_string(),
             title: "Test".to_string(),
             description: None,
             date_time: Utc::now(),
-            venue: None,
-            is_online: false,
+            venue,
+            is_online,
             num_free_spots: 1,
             rsvps_closed: false,
             short_url: "https://example.com".to_string(),
-        };
+        }
+    }
+
+    #[test]
+    fn event_without_venue_is_not_classified_as_online_by_default() {
+        let event = test_event(None, false);
 
         assert_eq!(EventCollector::event_location(&event), None);
+    }
+
+    #[test]
+    fn event_without_venue_but_marked_online_is_classified_as_online() {
+        let event = test_event(None, true);
+
+        assert_eq!(EventCollector::event_location(&event), Some(Location::Online));
+    }
+
+    #[test]
+    fn swissrpg_online_event_flows_through_to_online_free_spots_location() {
+        let event_series = crate::swissrpg::schema::Event {
+            uuid: Uuid::new_v4(),
+            title: "Test".to_string(),
+            public_url: "https://example.com".to_string(),
+            organisers: vec![],
+            description: None,
+            current_session: None,
+            upcoming_sessions: vec![],
+            legacy_id: None,
+            tags: vec![crate::swissrpg::schema::Tag {
+                code: crate::swissrpg::schema::LOCATION_CODE_ONLINE.to_string(),
+                value: "Online".to_string(),
+                tag_type: crate::swissrpg::schema::TAG_TYPE_LOCATION.to_string(),
+            }],
+        };
+        let session = crate::swissrpg::schema::Session {
+            uuid: Uuid::new_v4(),
+            number: 1,
+            start: Utc::now(),
+            attendees: vec![],
+            rsvp_open: true,
+            open_seats: 1,
+        };
+
+        let event = CommonEventDetails::from((&event_series, &session));
+
+        assert_eq!(EventCollector::event_location(&event), Some(Location::Online));
     }
 }

--- a/lib/src/swissrpg/schema.rs
+++ b/lib/src/swissrpg/schema.rs
@@ -17,6 +17,14 @@ pub struct Tag {
     pub tag_type: String,
 }
 
+pub(crate) const TAG_TYPE_LOCATION: &str = "location";
+pub(crate) const LOCATION_CODE_ONLINE: &str = "online";
+
+pub(crate) fn event_series_is_online(tags: &[Tag]) -> bool {
+    tags.iter()
+        .any(|tag| tag.tag_type == TAG_TYPE_LOCATION && tag.code == LOCATION_CODE_ONLINE)
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Session {
     pub uuid: Uuid,
@@ -83,4 +91,31 @@ pub struct ApiResponse<T> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocationsResponse {
     pub locations: Vec<Location>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_online_swissrpg_events_from_location_tag() {
+        let tags = vec![Tag {
+            code: LOCATION_CODE_ONLINE.to_string(),
+            value: "Online".to_string(),
+            tag_type: TAG_TYPE_LOCATION.to_string(),
+        }];
+
+        assert!(event_series_is_online(&tags));
+    }
+
+    #[test]
+    fn ignores_non_location_online_like_tags() {
+        let tags = vec![Tag {
+            code: LOCATION_CODE_ONLINE.to_string(),
+            value: "Online".to_string(),
+            tag_type: "game_type".to_string(),
+        }];
+
+        assert!(!event_series_is_online(&tags));
+    }
 }

--- a/lib/src/swissrpg/sync.rs
+++ b/lib/src/swissrpg/sync.rs
@@ -3,7 +3,12 @@ use std::{num::NonZeroU64, sync::Arc};
 
 use crate::{db, swissrpg::client::SwissRPGClient};
 
-use super::schema::{Event, Session};
+use super::schema::{Event, Session, Tag};
+
+pub(crate) fn event_series_is_online(tags: &[Tag]) -> bool {
+    tags.iter()
+        .any(|tag| tag.tag_type == "location" && tag.code == "online")
+}
 
 #[tracing::instrument(skip(swissrpg_client, db_connection))]
 pub async fn sync_task(
@@ -20,9 +25,10 @@ pub async fn sync_task(
         if let Some(event) = &event_series.current_session {
             if event.start > now {
                 // Add to EventCollector for free spots tracking
-                let common_event = crate::common_event::CommonEventDetails::from((&event_series, event));
+                let common_event =
+                    crate::common_event::CommonEventDetails::from((&event_series, event));
                 event_collector.add_event(common_event);
-                
+
                 match sync_event(&event_series, event, db_connection).await {
                     Err(err) => eprintln!("Event sync failed: {}", err),
                     _ => (),
@@ -34,9 +40,10 @@ pub async fn sync_task(
         for event in &event_series.upcoming_sessions {
             if event.start > now {
                 // Add to EventCollector for free spots tracking
-                let common_event = crate::common_event::CommonEventDetails::from((&event_series, event));
+                let common_event =
+                    crate::common_event::CommonEventDetails::from((&event_series, event));
                 event_collector.add_event(common_event);
-                
+
                 match sync_event(&event_series, event, db_connection).await {
                     Err(err) => eprintln!("Event sync failed: {}", err),
                     _ => (),
@@ -96,11 +103,14 @@ async fn sync_event_series(
             .fetch_one(&mut **tx)
             .await?;
 
-            if existing_swissrpg_id.is_some() && existing_swissrpg_id.as_ref() != Some(&event_series.uuid) {
+            if existing_swissrpg_id.is_some()
+                && existing_swissrpg_id.as_ref() != Some(&event_series.uuid)
+            {
                 return Err(simple_error::SimpleError::new(format!(
                     "Event series {} already has SwissRPG ID {:?}, cannot associate with {}",
                     indicated_event_series_id, existing_swissrpg_id, event_series.uuid
-                )).into());
+                ))
+                .into());
             }
 
             if existing_swissrpg_id.is_none() {
@@ -112,7 +122,7 @@ async fn sync_event_series(
                 )
                 .execute(&mut **tx)
                 .await?;
-                
+
                 println!(
                     "Event syncing task: Associated SwissRPG event series ID {} with existing event series {}",
                     event_series.uuid, indicated_event_series_id
@@ -152,6 +162,7 @@ pub async fn sync_event(
     db_connection: &sqlx::PgPool,
 ) -> Result<(), crate::BoxedError> {
     let mut tx = db_connection.begin().await?;
+    let is_online = event_series_is_online(&event_series.tags);
 
     // Step 1: Sync the event series first
     let series_id = sync_event_series(event_series, &mut tx).await?;
@@ -186,7 +197,7 @@ pub async fn sync_event(
             event.start,
             event_series.title,
             event_series.description,
-            false, // TODO: is_online
+            is_online,
             None as Option<i64>, // TODO: category_id
             db_event_id
         ).fetch_one(&mut *tx).await?
@@ -200,7 +211,7 @@ pub async fn sync_event(
             event.start,
             event_series.title,
             event_series.description,
-            false, // TODO: is_online
+            is_online,
             None as Option<i64>, // TODO: category_id
         ).fetch_one(&mut *tx).await?
     };
@@ -287,4 +298,32 @@ pub async fn sync_event(
         event.start.format("%Y-%m-%d %H:%M")
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swissrpg::schema::Tag;
+
+    #[test]
+    fn detects_online_swissrpg_events_from_location_tag() {
+        let tags = vec![Tag {
+            code: "online".to_string(),
+            value: "Online".to_string(),
+            tag_type: "location".to_string(),
+        }];
+
+        assert!(event_series_is_online(&tags));
+    }
+
+    #[test]
+    fn ignores_non_location_online_like_tags() {
+        let tags = vec![Tag {
+            code: "online".to_string(),
+            value: "Online".to_string(),
+            tag_type: "game_type".to_string(),
+        }];
+
+        assert!(!event_series_is_online(&tags));
+    }
 }

--- a/lib/src/swissrpg/sync.rs
+++ b/lib/src/swissrpg/sync.rs
@@ -3,12 +3,7 @@ use std::{num::NonZeroU64, sync::Arc};
 
 use crate::{db, swissrpg::client::SwissRPGClient};
 
-use super::schema::{Event, Session, Tag};
-
-pub(crate) fn event_series_is_online(tags: &[Tag]) -> bool {
-    tags.iter()
-        .any(|tag| tag.tag_type == "location" && tag.code == "online")
-}
+use super::schema::{event_series_is_online, Event, Session};
 
 #[tracing::instrument(skip(swissrpg_client, db_connection))]
 pub async fn sync_task(
@@ -298,32 +293,4 @@ pub async fn sync_event(
         event.start.format("%Y-%m-%d %H:%M")
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::swissrpg::schema::Tag;
-
-    #[test]
-    fn detects_online_swissrpg_events_from_location_tag() {
-        let tags = vec![Tag {
-            code: "online".to_string(),
-            value: "Online".to_string(),
-            tag_type: "location".to_string(),
-        }];
-
-        assert!(event_series_is_online(&tags));
-    }
-
-    #[test]
-    fn ignores_non_location_online_like_tags() {
-        let tags = vec![Tag {
-            code: "online".to_string(),
-            value: "Online".to_string(),
-            tag_type: "game_type".to_string(),
-        }];
-
-        assert!(!event_series_is_online(&tags));
-    }
 }


### PR DESCRIPTION
- Add missing implementation to check if an event (event_series) is online and if so create a voice channel
- Allow events without venues to be non online events (ex. if they're hosted privately, not in a public venue)

Closes: https://trello.com/c/nyGctyGN/10-10-no-voice-channel-created-for-online-games